### PR TITLE
Added Device Pixel Ratio

### DIFF
--- a/lib/src/flip_widget.dart
+++ b/lib/src/flip_widget.dart
@@ -110,7 +110,9 @@ class FlipWidgetState extends State<FlipWidget> {
     RenderObject? boundary = _renderKey.currentContext?.findRenderObject();
     if (boundary is RenderRepaintBoundary) {
       await _queueAction(() async {
-        var image = await boundary.toImage();
+        var image = await boundary.toImage(
+          pixelRatio: MediaQuery.of(context).devicePixelRatio,
+        );
         var buffer = await image.toByteData(format: ImageByteFormat.rawRgba);
         if (buffer != null) {
           var bytes = buffer.buffer.asUint8List(buffer.offsetInBytes, buffer.lengthInBytes);


### PR DESCRIPTION
Without the pixel ratio, shadows and other render objects depending on a pixel ratio will appear different from the original widget during flipping